### PR TITLE
增加了mediawiki模块user命令参数为空时查询群昵称的功能

### DIFF
--- a/modules/wiki/utils/__init__.py
+++ b/modules/wiki/utils/__init__.py
@@ -168,8 +168,19 @@ async def _(msg: Bot.MessageSession):
 usr = module("user", developers=["OasisAkari"], recommend_modules="wiki", doc=True)
 
 
+import re
+
 @usr.command("<username> {{I18N:wiki.help.user}}")
 async def _(msg: Bot.MessageSession, username: str):
+    if not username or not username.strip():
+        card = getattr(msg.session_info, "sender_card", None) or ""
+        match = re.match(r"(?i)^user:([^#]+)", card.strip())
+        if match:
+            username = match.group(1).strip()
+        if not username:
+            await msg.finish(I18NContext("wiki.message.user.no_username"))
+            return
+
     target = await WikiTargetInfo.get_by_target_id(msg.session_info.target_id)
     start_wiki = target.api_link
     headers = target.headers


### PR DESCRIPTION
代码为完全aigc，提交代码注释已删除，以下是带注释的代码
```
import re

@usr.command("<username> {{I18N:wiki.help.user}}") async def _(msg: Bot.MessageSession, username: str):
    # 1. 检查参数是否为空
    if not username or not username.strip():
        # 2. 获取群昵称，假设字段为 sender_card
        card = getattr(msg.session_info, "sender_card", None) or ""
        # 3. 正则匹配
        match = re.match(r"(?i)^user:([^#]+)", card.strip())
        if match:
            username = match.group(1).strip()
        # 如果没有匹配，返回提示
        if not username:
            await msg.finish(I18NContext("wiki.message.user.no_username"))
            return

    # 后续原有逻辑不变
    target = await WikiTargetInfo.get_by_target_id(msg.session_info.target_id)
    start_wiki = target.api_link
    headers = target.headers
    if start_wiki:
        match_interwiki = re.match(r"(.*?):(.*)", username)
        if match_interwiki:
            interwikis = target.interwikis
            if match_interwiki.group(1) in interwikis:
                await msg.finish(await get_user_info(
                    msg, match_interwiki.group(2), interwikis[match_interwiki.group(1)], headers
                ))
        await msg.finish(await get_user_info(msg, username, start_wiki, headers))
    else:
        await msg.finish(I18NContext("wiki.message.not_set"))
```